### PR TITLE
feat(payload): basic link buttons in Slate editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react": "^18.2.8",
         "@types/react-dom": "^18.2.4",
         "classnames": "^2.3.2",
+        "is-url": "^1.2.4",
         "payload": "^1.8.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -11485,6 +11486,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
     },
     "node_modules/is-weakmap": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/react": "^18.2.8",
     "@types/react-dom": "^18.2.4",
     "classnames": "^2.3.2",
+    "is-url": "^1.2.4",
     "payload": "^1.8.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/RichTextEditor/payload/elements/buttons/index.tsx
+++ b/src/components/RichTextEditor/payload/elements/buttons/index.tsx
@@ -1,10 +1,13 @@
 import { useSlate } from 'slate-react'
 import {
   Editor,
+  Range,
   Transforms,
   Element as SlateElement,
 } from 'slate'
 import { Button } from '../../../components'
+import { LinkElement } from '../../../types'
+import isUrl from 'is-url'
 
 const LIST_TYPES = ['ol', 'ul']
 const TEXT_ALIGN_TYPES = ['left', 'center', 'right', 'justify']
@@ -107,4 +110,119 @@ export const MarkButton = ({ format, icon }) => {
       {icon}
     </Button>
   )
+}
+
+const isLinkActive = editor => {
+  const [link] = Editor.nodes(editor, {
+    match: n =>
+      !Editor.isEditor(n) && SlateElement.isElement(n) && n.type === 'link',
+  })
+  return !!link
+}
+
+const insertLink = (editor, url) => {
+  if (editor.selection) {
+    wrapLink(editor, url)
+  }
+}
+
+const unwrapLink = editor => {
+  Transforms.unwrapNodes(editor, {
+    match: n =>
+      !Editor.isEditor(n) && SlateElement.isElement(n) && n.type === 'link',
+  })
+}
+
+const wrapLink = (editor, url: string) => {
+  if (isLinkActive(editor)) {
+    unwrapLink(editor)
+  }
+
+  const { selection } = editor
+  const isCollapsed = selection && Range.isCollapsed(selection)
+  const link: LinkElement = {
+    type: 'link',
+    url,
+    children: isCollapsed ? [{ text: url }] : [],
+  }
+
+  if (isCollapsed) {
+    Transforms.insertNodes(editor, link)
+  } else {
+    Transforms.wrapNodes(editor, link, { split: true })
+    Transforms.collapse(editor, { edge: 'end' })
+  }
+}
+
+export const AddLinkButton = ({ icon }) => {
+  const editor = useSlate()
+  return (
+    <Button
+      active={isLinkActive(editor)}
+      onMouseDown={event => {
+        event.preventDefault()
+        const url = window.prompt('Enter the URL of the link:')
+        if (!url) return
+        insertLink(editor, url)
+      }}
+    >
+      {icon}
+    </Button>
+  )
+}
+
+export const RemoveLinkButton = ({ icon }) => {
+  const editor = useSlate()
+
+  return (
+    <Button
+      active={isLinkActive(editor)}
+      onMouseDown={event => {
+        if (isLinkActive(editor)) {
+          unwrapLink(editor)
+        }
+      }}
+    >
+      {icon}
+    </Button>
+  )
+}
+
+export const withInlines = editor => {
+  const {
+    insertData,
+    insertText,
+    isInline,
+    isElementReadOnly,
+    isSelectable,
+  } = editor
+
+  editor.isInline = element =>
+    ['link', 'button', 'badge'].includes(element.type) || isInline(element)
+
+  editor.isElementReadOnly = element =>
+    element.type === 'badge' || isElementReadOnly(element)
+
+  editor.isSelectable = element =>
+    element.type !== 'badge' && isSelectable(element)
+
+  editor.insertText = text => {
+    if (text && isUrl(text)) {
+      wrapLink(editor, text)
+    } else {
+      insertText(text)
+    }
+  }
+
+  editor.insertData = data => {
+    const text = data.getData('text/plain')
+
+    if (text && isUrl(text)) {
+      wrapLink(editor, text)
+    } else {
+      insertData(data)
+    }
+  }
+
+  return editor
 }

--- a/src/components/RichTextEditor/payload/index.tsx
+++ b/src/components/RichTextEditor/payload/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useEffect, useMemo } from 'react'
 import isHotkey from 'is-hotkey'
 import { Editable, withReact, Slate } from 'slate-react'
 import { withHistory } from 'slate-history'
-import { BlockButton, MarkButton, toggleMark } from './elements/buttons'
+import { BlockButton, MarkButton, toggleMark, AddLinkButton, RemoveLinkButton, withInlines } from './elements/buttons'
 import { createEditor, Descendant } from 'slate'
 
 import { Toolbar } from '../components'
@@ -16,6 +16,8 @@ import {
   RiDoubleQuotesL,
   RiListOrdered,
   RiListUnordered,
+  RiLink,
+  RiLinkUnlink
 } from 'react-icons/ri'
 
 import { SlateValueContext } from '../../../contexts/SlateValueContext'
@@ -39,7 +41,10 @@ const RichTextEditor = ({
 }: IRichTextEditor) => {
   const renderElement = useCallback(props => <Element {...props} />, [])
   const renderLeaf = useCallback(props => <Leaf {...props} />, [])
-  const editor = useMemo(() => withHistory(withReact(createEditor())), [])
+  const editor = useMemo(
+    () => withInlines(withHistory(withReact(createEditor()))),
+    []
+  )
   const { setSlateValue } = useContext(SlateValueContext)
   useEffect(() => {
     setSlateValue(JSON.stringify(value))
@@ -81,6 +86,8 @@ const RichTextEditor = ({
         <BlockButton format="blockquote" icon={<RiDoubleQuotesL />} />
         <BlockButton format="ol" icon={<RiListOrdered />} />
         <BlockButton format="ul" icon={<RiListUnordered />} />
+        <AddLinkButton icon={<RiLink />} />
+        <RemoveLinkButton icon={<RiLinkUnlink />} />
       </Toolbar>
       <Editable
         className={cx(
@@ -153,6 +160,12 @@ const Element = ({ attributes, children, element }) => {
         <ol style={style} {...attributes}>
           {children}
         </ol>
+      )
+    case 'link':
+      return (
+        <a style={style} {...attributes}>
+          {children}
+        </a>
       )
     default:
       return (

--- a/src/components/RichTextEditor/types.ts
+++ b/src/components/RichTextEditor/types.ts
@@ -1,5 +1,5 @@
 import { ReactEditor } from 'slate-react'
-import { BaseEditor } from 'slate'
+import { BaseEditor, Descendant } from 'slate'
 
 /**
  * Define Slate JS types for all editor
@@ -7,6 +7,8 @@ import { BaseEditor } from 'slate'
  * 
  * @see https://docs.slatejs.org/concepts/12-typescript#defining-editor-element-and-text-types
  */
+
+export type LinkElement = { type: 'link'; url: string; children: Descendant[] }
 
 type CustomElement = {
   type:
@@ -24,8 +26,8 @@ type CustomElement = {
     | 'list-item'
     | 'link';
   align?: string;
-  children: CustomText[]
-}
+  children: CustomText[] | Descendant[]
+} | LinkElement
 type CustomText = { text: string; bold?: boolean; italic?: boolean; code?: boolean }
 
 declare module 'slate' {


### PR DESCRIPTION
Reference: https://www.slatejs.org/examples/inlines.