### PR TITLE
feat(slatetoreact): demo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.5.2",
-        "@types/node": "^20.3.1",
+        "@types/node": "^20.3.2",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
         "classnames": "^2.3.2",
@@ -32,7 +32,7 @@
         "slate": "^0.94.1",
         "slate-history": "^0.93.0",
         "slate-react": "^0.97.1",
-        "slate-serializers": "^0.3.0",
+        "slate-serializers": "^0.4.0",
         "stringify-object": "^5.0.0",
         "typescript": "^4.9.5",
         "web-vitals": "^3.3.2"
@@ -4874,9 +4874,9 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
     },
     "node_modules/@types/node": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
+      "version": "20.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
+      "integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -19502,9 +19502,9 @@
       "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
     },
     "node_modules/slate-serializers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/slate-serializers/-/slate-serializers-0.3.0.tgz",
-      "integrity": "sha512-YaaKa1U5+pPDjWFWIQT1+EWDrZCnsZj2HkmlTBHU/0EQ4d5qQJfADmUeWWM9/n2R1w9EG8hl0jBwH4Yd/Ts/lg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/slate-serializers/-/slate-serializers-0.4.0.tgz",
+      "integrity": "sha512-RUKSVz6MYtpJN/gVBB2njLiVlbPrw3ZigSFHFgU6qfhqpfRtezTkyCUT76jAQdTGyRHVBW6ny+Vvjv/uTnSa6A==",
       "dependencies": {
         "@testing-library/react": "^14.0.0",
         "css-select": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.5.2",
-    "@types/node": "^20.3.1",
+    "@types/node": "^20.3.2",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
     "classnames": "^2.3.2",
@@ -28,7 +28,7 @@
     "slate": "^0.94.1",
     "slate-history": "^0.93.0",
     "slate-react": "^0.97.1",
-    "slate-serializers": "^0.3.0",
+    "slate-serializers": "^0.4.0",
     "stringify-object": "^5.0.0",
     "typescript": "^4.9.5",
     "web-vitals": "^3.3.2"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Header from './components/Header'
 
 import SlateToHtmlDemo from './pages/slateToHtml'
 import HtmlToSlateDemo from './pages/htmlToSlate'
+import SlateToReactDemo from './pages/slateToReact'
 
 export default function App() {
   return (
@@ -17,6 +18,7 @@ export default function App() {
         <Route path="/" element={<Layout />}>
           <Route index element={<SlateToHtmlDemo />} />
           <Route path="htmltoslate" element={<HtmlToSlateDemo />} />
+          <Route path="slatetoreact" element={<SlateToReactDemo />} />
 
           {/* Using path="*"" means "match anything", so this route
                 acts like a catch-all for URLs that we don't have explicit

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -14,6 +14,10 @@ const navigation = [
     name: 'htmlToSlate',
     to: '/htmltoslate'
   },
+  /**{
+    name: 'slateToReact',
+    to: '/slatetoreact'
+  },*/
 ]
 
 function classNames(...classes) {

--- a/src/components/PageHeading/react/Select/index.tsx
+++ b/src/components/PageHeading/react/Select/index.tsx
@@ -1,0 +1,318 @@
+import { Fragment, useContext, useState } from 'react'
+import { Listbox, Transition } from '@headlessui/react'
+import { CheckIcon, ChevronDownIcon } from '@heroicons/react/20/solid'
+import {
+  slateToDomConfig,
+  payloadSlateToDomConfig,
+  slateDemoSlateToDomConfig,
+} from 'slate-serializers'
+import {
+  slateToReactConfig
+} from 'slate-serializers/lib/react'
+import { Descendant } from 'slate'
+import { SlateValueContext } from '../../../../contexts/SlateValueContext'
+
+export const initialValue: any[] = [
+  {
+      "children": [
+          {
+              "text": "slateToReact"
+          }
+      ],
+      "type": "h2"
+  },
+  {
+      "children": [
+          {
+              "text": "Demo"
+          }
+      ],
+      "type": "h3"
+  },
+  {
+      "type": "p",
+      "children": [
+          {
+              "text": "Try changing the contents of this editor. The rest of the page updates as you make changes to demonstrate:"
+          }
+      ]
+  },
+  {
+      "type": "ul",
+      "children": [
+          {
+              "children": [
+                  {
+                      "text": "the Slate JSON value;"
+                  }
+              ],
+              "type": "li"
+          },
+          {
+              "type": "li",
+              "children": [
+                  {
+                      "text": "content rendered using the "
+                  },
+                  {
+                      "text": "<SlateToReact>",
+                      "code": true
+                  },
+                  {
+                      "text": " component."
+                  }
+              ]
+          }
+      ]
+  },
+]
+
+export const slateValue: Descendant[] = [
+  {
+    type: 'paragraph',
+    children: [
+      { text: 'This is editable ' },
+      { text: 'rich', bold: true },
+      { text: ' text, ' },
+      { text: 'much', italic: true },
+      { text: ' better than a ' },
+      { text: '<textarea>', code: true },
+      { text: '!' },
+    ],
+  },
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text:
+          "Since it's rich text, you can do things like turn a selection of text ",
+      },
+      { text: 'bold', bold: true },
+      {
+        text:
+          ', or add a semantically rendered block quote in the middle of the page, like this:',
+      },
+    ],
+  },
+  {
+    type: 'block-quote',
+    children: [{ text: 'A wise quote.' }],
+  },
+  {
+    type: 'paragraph',
+    align: 'center',
+    children: [{ text: 'Try it out for yourself!' }],
+  },
+]
+
+export const payloadValue: any[] = [
+  {
+    children: [
+      { text: 'The ' },
+      { text: 'Payload CMS', bold: true },
+      { text: ' configuration is ' },
+      { text: 'very similar to the default', italic: true },
+      { text: ' because it imports the default configuration as a base.' },
+    ],
+  },
+  {
+    children: [
+      {
+        text:
+          "For this configuration, Slate nodes without a type are serialized to ",
+      },
+      {
+        code: true,
+        text:
+          "p",
+      },
+      {
+        text:
+          " HTML element tags.",
+      },
+    ],
+  },
+  {
+    children: [
+      {
+        text:
+          "Note some custom element transforms:",
+      },
+    ],
+  },
+  {
+    type: 'h2',
+    children: [{ text: 'Links' }],
+  },
+  {
+    type: "ul",
+    children: [
+        {
+            type: "li",
+            children: [
+              {
+                type: 'link',
+                linkType: 'custom',
+                newTab: true,
+                url: "https://github.com/thompsonsj/slate-serializers",
+                children: [{ text: 'A data attribute is added to link HTML to keep track of Payload\'s link type.' }],
+              },
+            ]
+        },
+        {
+          type: "li",
+          children: [
+            {
+              text:
+                " The ",
+            },
+            {
+              code: true,
+              text:
+                "target",
+            },
+            {
+              text:
+                " and ",
+            },
+            {
+              code: true,
+              text:
+                "href",
+            },
+            {
+              text:
+                " attributes are also supported.",
+            },
+          ]
+        }
+    ]
+  },
+]
+
+const publishingOptions = [
+  {
+    title: 'Default',
+    description: 'Default configuration.',
+    current: true,
+    config: {
+      configName: "Default",
+      configSlug: "default",
+      configUrlDom: "https://github.com/thompsonsj/slate-serializers/blob/main/src/config/slateToDom/default.ts",
+      configUrl: "https://github.com/thompsonsj/slate-serializers/blob/main/src/config/slateToReact/default.tsx",
+      slateToDomConfig: slateToDomConfig,
+      slateToReactConfig: slateToReactConfig, 
+      initialValue,
+    }
+  },
+  {
+    title: 'Slate demo',
+    description: 'Uses a similar configuration to the examples provided on the Slate JS website.',
+    current: false,
+    config: {
+      configName: "Slate demo",
+      configSlug: "slate",
+      configUrlDom: "https://github.com/thompsonsj/slate-serializers/blob/main/src/config/slateToDom/slateDemo.ts",
+      configUrl: "https://github.com/thompsonsj/slate-serializers/blob/main/src/config/slateToReact/slateDemo.tsx",
+      slateToDomConfig: slateDemoSlateToDomConfig,
+      slateToReactConfig: slateToReactConfig, 
+      initialValue: slateValue,
+    }
+  },
+  {
+    title: 'Payload CMS',
+    description: 'Configuration designed to work with the Slate JS implementation in Payload CMS.',
+    current: false,
+    config: {
+      configName: "Payload CMS",
+      configSlug: "payload",
+      configUrlDom: "https://github.com/thompsonsj/slate-serializers/blob/main/src/config/slateToDom/payload.ts",
+      configUrl: "https://github.com/thompsonsj/slate-serializers/blob/main/src/config/slateToReact/payload.tsx",
+      slateToDomConfig: payloadSlateToDomConfig,
+      slateToReactConfig: slateToReactConfig,  
+      initialValue: payloadValue,
+    }
+  },
+]
+
+function classNames(...classes) {
+  return classes.filter(Boolean).join(' ')
+}
+
+interface ISelect {
+  setSlateConfig?: () => {}
+}
+
+export const Select = ({
+  setSlateConfig
+}) => {
+  const [selected, setSelected] = useState(publishingOptions[0])
+  const { setSlateValue } = useContext(SlateValueContext)
+
+  const onChange = (event) => {
+    setSlateConfig(event.config)
+    setSlateValue(JSON.stringify(event.config.initialValue))
+    setSelected(event)
+  }
+
+  return (
+    <Listbox value={selected} onChange={onChange}>
+      {({ open }) => (
+        <>
+          <Listbox.Label className="sr-only">Change configuration</Listbox.Label>
+          <div className="relative">
+            <div className="inline-flex divide-x divide-indigo-700 rounded-md shadow-sm">
+              <div className="inline-flex items-center gap-x-1.5 rounded-l-md bg-indigo-600 px-3 py-2 text-white shadow-sm">
+                <CheckIcon className="-ml-0.5 h-5 w-5" aria-hidden="true" />
+                <p className="text-sm font-semibold">{selected.title}</p>
+              </div>
+              <Listbox.Button className="inline-flex items-center rounded-l-none rounded-r-md bg-indigo-600 p-2 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 focus:ring-offset-gray-50">
+                <span className="sr-only">Change configuration</span>
+                <ChevronDownIcon className="h-5 w-5 text-white" aria-hidden="true" />
+              </Listbox.Button>
+            </div>
+
+            <Transition
+              show={open}
+              as={Fragment}
+              leave="transition ease-in duration-100"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <Listbox.Options className="absolute right-0 z-10 mt-2 w-72 origin-top-right divide-y divide-gray-200 overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+                {publishingOptions.map((option) => (
+                  <Listbox.Option
+                    key={option.title}
+                    className={({ active }) =>
+                      classNames(
+                        active ? 'bg-indigo-600 text-white' : 'text-gray-900',
+                        'cursor-default select-none p-4 text-sm'
+                      )
+                    }
+                    value={option}
+                  >
+                    {({ selected, active }) => (
+                      <div className="flex flex-col">
+                        <div className="flex justify-between">
+                          <p className={selected ? 'font-semibold' : 'font-normal'}>{option.title}</p>
+                          {selected ? (
+                            <span className={active ? 'text-white' : 'text-indigo-600'}>
+                              <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                            </span>
+                          ) : null}
+                        </div>
+                        <p className={classNames(active ? 'text-indigo-200' : 'text-gray-500', 'mt-2')}>
+                          {option.description}
+                        </p>
+                      </div>
+                    )}
+                  </Listbox.Option>
+                ))}
+              </Listbox.Options>
+            </Transition>
+          </div>
+        </>
+      )}
+    </Listbox>
+  )
+}

--- a/src/components/PageHeading/react/index.tsx
+++ b/src/components/PageHeading/react/index.tsx
@@ -1,0 +1,64 @@
+import { FC, Fragment, useContext, ReactNode } from 'react'
+import {
+  CogIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  LinkIcon,
+  PencilIcon,
+} from '@heroicons/react/20/solid'
+import { Menu, Transition } from '@headlessui/react'
+import { Select } from './Select'
+import cx from "classnames"
+import { SlateToReactConfigContext } from '../../../contexts/SlateToReactConfigContext'
+
+const configs = {
+  slateToDom: {
+    text: "Default",
+    url: "https://github.com/thompsonsj/slate-serializers/blob/main/src/config/slateToDom/default.ts",
+  },
+  htmlToSlate: {
+    text: "Default",
+    url: "https://github.com/thompsonsj/slate-serializers/blob/main/src/config/htmlToSlate/default.ts",
+  }
+}
+
+interface IPageHeading {
+  title?: string
+  config?: "htmlToSlate" | "slateToDom"
+  menu: ReactNode
+  className?: string
+}
+
+export const PageHeading: FC<IPageHeading> = ({
+  title,
+  config = "htmlToSlate",
+  menu,
+  className
+}) => {
+  const { configName, configUrl, configUrlDom } = useContext(SlateToReactConfigContext)
+
+  return (
+    <div className={className}>
+      <div className="lg:flex lg:items-center lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <h2 className="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">
+            {title}
+          </h2>
+          <div className="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
+            {configName && (
+            <div className="mt-2 flex items-center text-sm text-gray-500">
+              <CogIcon className="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400" aria-hidden="true" />
+              <strong>Config:&nbsp;&nbsp;</strong> <a target="_blank" className="underline" href=
+              {configUrlDom}>{configName} (Dom)</a>, &nbsp; <a target="_blank" className="underline" href=
+              {configUrl}>{configName} (React)</a>.
+            </div>
+            )}
+          </div>
+        </div>
+        <div className="mt-5 flex lg:ml-4 lg:mt-0">
+          {menu}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/SlateToReactDemo/index.tsx
+++ b/src/components/SlateToReactDemo/index.tsx
@@ -1,0 +1,83 @@
+import React, { FC, useEffect, useState } from 'react'
+import stringifyObject from 'stringify-object'
+
+import { PageHeading } from '../PageHeading/react'
+import RichTextEditor from '../RichTextEditor/default'
+import PayloadRichTextEditor from '../RichTextEditor/payload'
+import SlateDemoRichTextEditor from '../RichTextEditor/slate-demo'
+
+import { SlateValueContext } from '../../contexts/SlateValueContext'
+import { IConfigContext, SlateToReactConfigContext } from '../../contexts/SlateToReactConfigContext'
+import { Select } from '../PageHeading/react/Select';
+import { initialValue as startValue } from '../PageHeading/react/Select'
+
+
+import { SlateToReact, slateToReactConfig } from "slate-serializers/lib/react"
+import { slateToDomConfig } from 'slate-serializers'
+
+export const SlateToReactDemo: FC = () => {
+  const [slateConfig, setSlateConfig] = useState<IConfigContext>({
+    configName: "Default",
+    configSlug: "default",
+    configUrlDom: "https://github.com/thompsonsj/slate-serializers/blob/main/src/config/slateToDom/default.ts",
+    configUrl: "https://github.com/thompsonsj/slate-serializers/blob/main/src/config/slateToReact/default.tsx",
+    slateToDomConfig: slateToDomConfig,
+    slateToReactConfig: slateToReactConfig,
+    initialValue: startValue,
+  });
+  const [slateValue, setSlateValue] = useState(JSON.stringify(startValue))
+  const [ jsx, setJsx ] = useState(slateValue ? <SlateToReact node={JSON.parse(slateValue)} config={slateConfig.slateToDomConfig} reactConfig={slateConfig.slateToReactConfig} />: <></>)
+
+  useEffect(() => {
+    setJsx(slateValue ? <SlateToReact node={JSON.parse(slateValue)} config={slateConfig.slateToDomConfig} reactConfig={slateConfig.slateToReactConfig} />: <></>)
+  }, [slateValue, slateToDomConfig, slateToReactConfig])
+
+  return (
+    <>
+    <SlateToReactConfigContext.Provider value={slateConfig}>
+      <SlateValueContext.Provider value={{
+        slateValue, setSlateValue
+      }}>
+        <PageHeading
+          title="Convert Slate JSON to React JSX"
+          config="slateToDom"
+          menu={<Select
+            setSlateConfig={setSlateConfig}
+          />}
+          className="p-6 mt-8 bg-slate-200 rounded"
+        />
+        <div className="grid grid-cols-12 gap-6 py-12">
+          <div className="col-span-6">
+            <label className="block font-bold text-gray-700 mb-6">
+              Edit Slate content
+            </label>
+            {slateConfig.configSlug === "default" && (
+            <RichTextEditor value={slateConfig.initialValue} />
+            )}
+            {slateConfig.configSlug === "payload" && (
+            <PayloadRichTextEditor value={slateConfig.initialValue} />
+            )}
+            {slateConfig.configSlug === "slate" && (
+            <SlateDemoRichTextEditor value={slateConfig.initialValue} />
+            )}
+          </div>
+          <div className="col-span-6">
+            <label className="block font-bold text-gray-700 mb-6">
+              slateToReact output
+            </label>
+            <div className="prose p-6 bg-slate-100">{jsx}</div>
+          </div>
+        </div>
+        <div className="grid grid-cols-12 gap-6 py-12">
+          <div className="col-span-6">
+            <label className="block font-bold text-gray-700 mb-6">
+              Slate value
+            </label>
+            <pre><code>{slateValue && JSON.parse(slateValue).map(node => stringifyObject(node)).join('\n')}</code></pre>
+          </div>
+        </div>
+      </SlateValueContext.Provider>
+      </SlateToReactConfigContext.Provider>
+    </>
+  )
+}

--- a/src/contexts/SlateToReactConfigContext.tsx
+++ b/src/contexts/SlateToReactConfigContext.tsx
@@ -1,0 +1,26 @@
+import { createContext } from "react";
+import { SlateToReactConfig } from "slate-serializers/lib/react";
+import { Descendant } from "slate";
+import { SlateToDomConfig } from "slate-serializers";
+
+export interface IConfigContext {
+  configName: string
+  configSlug: string
+  configUrlDom: string
+  configUrl: string
+  slateToDomConfig: SlateToDomConfig
+  slateToReactConfig: SlateToReactConfig
+  initialValue: Descendant[]
+}
+
+const defaultValue = {
+  configName: "",
+  configSlug: "",
+  configUrlDom: "",
+  configUrl: "",
+  slateToDomConfig: null,
+  slateToReactConfig: null,
+  initialValue: [],
+}
+
+export const SlateToReactConfigContext = createContext<IConfigContext>(defaultValue);

--- a/src/pages/slateToReact/index.tsx
+++ b/src/pages/slateToReact/index.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react'
+import { Descendant } from 'slate'
+import { SlateToReactDemo } from '../../components/SlateToReactDemo';
+import { slateDemoSlateToDomConfig, slateDemoHtmlToSlateConfig, slateToDomConfig } from "slate-serializers"
+import { ModalProvider, ModalContainer } from '@faceless-ui/modal';
+
+const initialValue: Descendant[] = [
+  {
+    type: 'paragraph',
+    children: [
+      { text: 'This is editable ' },
+      { text: 'rich', bold: true },
+      { text: ' text, ' },
+      { text: 'much', italic: true },
+      { text: ' better than a ' },
+      { text: '<textarea>', code: true },
+      { text: '!' },
+    ],
+  },
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text:
+          "Since it's rich text, you can do things like turn a selection of text ",
+      },
+      { text: 'bold', bold: true },
+      {
+        text:
+          ', or add a semantically rendered block quote in the middle of the page, like this:',
+      },
+    ],
+  },
+  {
+    type: 'block-quote',
+    children: [{ text: 'A wise quote.' }],
+  },
+  {
+    type: 'paragraph',
+    align: 'center',
+    children: [{ text: 'Try it out for yourself!' }],
+  },
+]
+
+const App = () => {
+  
+
+  return (
+    <ModalProvider>
+      <SlateToReactDemo />
+      <ModalContainer />
+    </ModalProvider>
+  )}
+
+export default App;


### PR DESCRIPTION
Note that `slateDemo` doesn't work because it sets an invalid style attribute. Support for this needs to be added in https://github.com/thompsonsj/slate-serializers.

```
Uncaught Error: The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + 'em'}} when using JSX.
    at assertValidProps (react-dom.development.js:2963:1)
    at setInitialProperties (react-dom.development.js:9920:1)
    at finalizeInitialChildren (react-dom.development.js:10950:1
```